### PR TITLE
Clarify that import obviates need for null export (?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ for the July 2016 ECMA TC39 meeting.
 
 The proposal is to require that Module source text has at least one `import` or
 `export` statement. This should feel natural to developers as most modules import
-dependencies and/or export APIs. Modules that do not export anything should
+dependencies and/or export APIs. Modules that do not import or export anything should
 explicitly specify an `export default null` to make their intentions clear.
 
 ### Script Example


### PR DESCRIPTION
Can you please clarify the meaning of this sentence for me? In isolation it's a little ambiguous:

> Modules that do not export anything should explicitly specify an `export default null` to make their intentions clear.

Based on the first sentence of the paragraph, presence of an `import` is sufficient to classify the source text as Module. The advice is to add the `export default null` only if there's no `import`, not literally add it whenever there's no `export` (even when there is `import`), right?

Thanks!
